### PR TITLE
履歷（個人資料）顯示頁路徑修復

### DIFF
--- a/resume/urls.py
+++ b/resume/urls.py
@@ -20,5 +20,5 @@ urlpatterns = [
     path('project/show/',ProjectListView.as_view(),name='project-show'),
     path('project/edit/<pk>', ProjectUpdateView.as_view(), name='project-edit'),
     path('project/delete/<pk>', ProjectDeleteView.as_view(), name='project-delete'),
-    path('<pk>',ProfileListView.as_view(),name='show'),
+    path('<pk>/',ProfileListView.as_view(),name='show'),
 ]


### PR DESCRIPTION
#37 
履歷（個人資料）顯示頁路徑修復
更正為：path('<pk>/',ProfileListView.as_view(),name='show'),