### PR TITLE
重建會員系統 多一個欄位分別 user 和 company

### DIFF
--- a/companies/views.py
+++ b/companies/views.py
@@ -43,7 +43,7 @@ class CompanyUpdateView(LoginRequiredMixin, UpdateView):
     model = CustomUser
     form_class = CompanyUpdateForm
     template_name = 'companies/update.html'
-    success_url = reverse_lazy('company_detail')
+    success_url = "/companies/"
     login_url = "/companies/"
 
     def get_queryset(self):

--- a/core/settings.py
+++ b/core/settings.py
@@ -207,7 +207,7 @@ AWS_DEFAULT_ACL = None
 
 
 AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
+    # 'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -17,7 +17,7 @@ class AddView(CreateView):
 
     def form_valid(self, form):
         pk = self.kwargs.get('pk')
-        self.success_url = f"/companies/{pk}/jobs" 
+        self.success_url = f"/companies/{pk}/jobs/" 
         return super().form_valid(form)
 
 
@@ -36,7 +36,7 @@ class EditView(UpdateView):
 
     def form_valid(self, form):
         pk = self.kwargs.get('pk')
-        self.success_url = f"/companies/{pk}/jobs" 
+        self.success_url = f"/companies/{pk}/jobs/" 
         return super().form_valid(form)
 
 
@@ -46,5 +46,5 @@ class JobDeleteView(DeleteView):
 
     def form_valid(self, form):
         pk = self.kwargs.get('pk')
-        self.success_url = f"/companies/{pk}/jobs" 
+        self.success_url = f"/companies/{pk}/jobs/" 
         return super().form_valid(form)

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load socialaccount %}
 {% block content %}
     <h2>User Login</h2>
     <form method="post">
@@ -6,5 +7,8 @@
         {{ form.as_p }}
         <button type="submit">Login</button>
     </form>
+    <br>
+    <a href="{% provider_login_url 'google' %}">Google帳號登入</a>
+    <br>
     <p>Don't have an account? <a href="{% url 'users:register' %}">Register here</a>.</p>
 {% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -30,7 +30,7 @@ class UserLoginView(LoginView):
         return reverse_lazy('users:home')
 
 class UserLogoutView(LogoutView):
-    next_page = "/"
+    next_page = reverse_lazy('home')
 
 class UserDetailView(LoginRequiredMixin, DetailView):
     model = CustomUser


### PR DESCRIPTION
1. 進入首頁時,透過表單的btn將參數user or company帶入登入頁面.
2. 舉例: 一般使用者註冊時, 會將role欄位帶入"user", 並儲存
3. 已註冊過的使用者或是公司戶想偷渡的話會在signinView中的form_valid中判斷role的值, 但我還沒寫, 明早會寫, 感謝!!!
4. 截圖為test1112的role欄位, 成功寫入user
<img width="948" alt="截圖 2024-05-13 晚上11 23 36" src="https://github.com/astrocamp/16th-EngiLink/assets/111471602/d3b99bf9-b011-45a9-b6a7-0cd81d4ef48b">
