### PR TITLE
修正user.form和users.models邏輯重複部分

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -7,17 +7,6 @@ class UserRegisterForm(UserCreationForm):
     class Meta:
         model = CustomUser
         fields = ('username', 'email', 'password1', 'password2')
-
-    def __init__(self, *args, **kwargs):
-        super(UserRegisterForm, self).__init__(*args, **kwargs)
-        self.initial['user_type'] = 1  # Automatically set user_type for 'user'
-
-    def save(self, commit=True):
-        user = super(UserRegisterForm, self).save(commit=False)
-        user.user_type = 1  # Set user_type for 'user'
-        if commit:
-            user.save()
-        return user
     
 class UserUpdateForm(UserChangeForm):
     class Meta:


### PR DESCRIPTION
users.models中CustomUser的user_type已有預設值1(等於求職者）
<img width="972" alt="截圖 2024-05-20 20 37 15" src="https://github.com/astrocamp/16th-EngiLink/assets/157874138/d2164cba-8045-42eb-985e-dd871460f99a">

user.form中不需要再寫self.initial['user_type'] = 1 或自定義save方法