### PR TITLE
新增權限管理

### DIFF
--- a/companies/rules.py
+++ b/companies/rules.py
@@ -2,8 +2,7 @@ import rules
 
 @rules.predicate
 def is_company(custom_user):
-    return custom_user.user_type == 2
+    return custom_user.is_authenticated and custom_user.user_type == 2
 
 
-rules.add_perm('companies.detail_company',is_company)
-rules.add_perm('companies.home_company',is_company)
+rules.add_perm('company_can_show',is_company)

--- a/educations/__init__.py
+++ b/educations/__init__.py
@@ -1,0 +1,1 @@
+from . import rules

--- a/educations/rules.py
+++ b/educations/rules.py
@@ -1,0 +1,8 @@
+import rules
+
+@rules.predicate
+def is_education_user(user,education):
+    return user == education.resume.user
+
+def add_rule():
+    rules.add_rule('is_education_user',is_education_user)

--- a/educations/views.py
+++ b/educations/views.py
@@ -3,13 +3,14 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, ListView, UpdateView, DeleteView
 from .models import Education
 from .forms import EducationForm
+from django.contrib.auth.mixins import PermissionRequiredMixin
 
-
-class EducationCreateView(CreateView):
+class EducationCreateView(PermissionRequiredMixin,CreateView):
     model = Education
     form_class = EducationForm
-    template_name = "educations/create.html"
-    success_url = reverse_lazy("resumes:edu-show")
+    template_name = 'educations/create.html'
+    success_url = reverse_lazy('resumes:edu-show')
+    permission_required = "user_can_show"
 
     def form_valid(self, form):
         messages.success(self.request, "新增成功")
@@ -17,10 +18,11 @@ class EducationCreateView(CreateView):
         return super().form_valid(form)
 
 
-class EducationListView(ListView):
+class EducationListView(PermissionRequiredMixin,ListView):
     model = Education
-    template_name = "educations/index.html"
-    context_object_name = "educations"
+    template_name = 'educations/index.html'
+    context_object_name = 'educations' 
+    permission_required = "user_can_show"
 
     def get_queryset(self):
         return Education.objects.filter(resume__user=self.request.user)

--- a/jobs/rules.py
+++ b/jobs/rules.py
@@ -4,5 +4,10 @@ import rules
 def is_company(custom_user):
     return custom_user.user_type == 2
 
+@rules.predicate
+def is_current_company(user,company):
+    return user == company.custom_user
+
 
 rules.add_perm('jobs.show_job',is_company)
+rules.add_rule('is_current_company',is_current_company)

--- a/jobs/rules.py
+++ b/jobs/rules.py
@@ -5,8 +5,8 @@ def is_company(custom_user):
     return custom_user.user_type == 2
 
 @rules.predicate
-def is_current_company(user,company):
-    return user == company.custom_user
+def is_current_company(company_user,company):
+    return company_user == company.custom_user
 
 
 rules.add_perm('jobs.show_job',is_company)

--- a/jobs/urls.py
+++ b/jobs/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ShowView, EditView, JobDeleteView,SetPublishView, JobListView
+from .views import ShowView, EditView, JobDeleteView,PublishView, JobListView
 
 
 app_name = "jobs"
@@ -8,6 +8,6 @@ urlpatterns = [
     path('list/', JobListView.as_view(), name='job_list'),
     path("edit/<int:pk>/", EditView.as_view(), name="edit"),
     path("delete/<int:pk>/", JobDeleteView.as_view(), name="delete"),
-    path("setpublish/<int:pk>", SetPublishView.as_view(), name="setpublish"),
+    path("publish/<int:pk>", PublishView.as_view(), name="publish"),
     path("<int:pk>/", ShowView.as_view(), name="show"),
 ]

--- a/projects/__init__.py
+++ b/projects/__init__.py
@@ -1,0 +1,1 @@
+from . import rules

--- a/projects/rules.py
+++ b/projects/rules.py
@@ -1,0 +1,8 @@
+import rules
+
+@rules.predicate
+def is_project_user(user,education):
+    return user == education.resume.user
+
+def add_rule():
+    rules.add_rule('is_project_user',is_project_user)

--- a/projects/views.py
+++ b/projects/views.py
@@ -3,24 +3,26 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, ListView, UpdateView, DeleteView
 from .models import Project
 from .forms import ProjectForm
+from django.contrib.auth.mixins import PermissionRequiredMixin
 
 
-class ProjectCreateView(CreateView):
+class ProjectCreateView(PermissionRequiredMixin,CreateView):
     model = Project
     form_class = ProjectForm
-    template_name = "projects/create.html"
-    success_url = reverse_lazy("resumes:project-show")
+    template_name = 'projects/create.html'
+    success_url = reverse_lazy('resumes:project-show')
+    permission_required = "user_can_show"
 
     def form_valid(self, form):
         messages.success(self.request, "新增成功")
         self.object = form.save()
         return super().form_valid(form)
-
-
-class ProjectListView(ListView):
+    
+class ProjectListView(PermissionRequiredMixin,ListView):
     model = Project
-    template_name = "projects/index.html"
-    context_object_name = "projects"
+    template_name = 'projects/index.html'
+    context_object_name = 'projects' 
+    permission_required = "user_can_show"
 
     def get_queryset(self):
         return Project.objects.filter(resume__user=self.request.user)
@@ -31,6 +33,7 @@ class ProjectUpdateView(UpdateView):
     form_class = ProjectForm
     template_name = "projects/update.html"
     success_url = reverse_lazy("resumes:project-show")
+
 
     def form_valid(self, form):
         messages.success(self.request, "更新成功")

--- a/resumes/__init__.py
+++ b/resumes/__init__.py
@@ -1,1 +1,2 @@
 from . import rules
+default_app_config = 'resumes.apps.ResumeConfig'

--- a/resumes/apps.py
+++ b/resumes/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class ResumeConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "resumes"
+
+    def ready(self):
+        import educations.rules
+        educations.rules.add_rule()

--- a/resumes/rules.py
+++ b/resumes/rules.py
@@ -2,8 +2,8 @@ import rules
 
 
 @rules.predicate
-def is_user(custom_user):
-    return custom_user.user_type == 1
+def is_resume_user(user,resume):
+    return user == resume.user
 
-
-rules.add_perm('resumes.show_job',is_user)
+def add_rule():
+    rules.add_rule('is_resume_user',is_resume_user)

--- a/resumes/views.py
+++ b/resumes/views.py
@@ -18,13 +18,13 @@ from projects.models import Project
 from weasyprint import HTML, CSS
 from django.template.loader import render_to_string
 from django.contrib.auth.mixins import PermissionRequiredMixin
-
 import json
 
 
-class ResumeArea(PermissionRequiredMixin, TemplateView):
-    template_name = "resumes/area.html"
-    permission_required = "resumes.show_job"
+
+class ResumeArea(PermissionRequiredMixin,TemplateView):
+    template_name = 'resumes/area.html'
+    permission_required = "user_can_show"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -36,8 +36,9 @@ class ResumeArea(PermissionRequiredMixin, TemplateView):
 
 class ResumeListView(ListView):
     model = Resume
-    template_name = "resumes/index.html"
-    context_object_name = "resumes"
+    template_name = 'resumes/index.html'
+    context_object_name = 'resumes' 
+
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -46,12 +47,14 @@ class ResumeListView(ListView):
         return context
 
 
-class ResumeCreateView(LoginRequiredMixin, CreateView):
+class ResumeCreateView(PermissionRequiredMixin,LoginRequiredMixin, CreateView):
     model = Resume
     form_class = ResumeForm
-    template_name = "resumes/create.html"
-    success_url = reverse_lazy("resumes:index")
+    template_name = 'resumes/create.html'
+    success_url = reverse_lazy('resumes:index')
+    permission_required = "user_can_show"
 
+    
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["request"] = self.request
@@ -68,6 +71,7 @@ class ResumeUpdateView(UpdateView):
     form_class = ResumeForm
     template_name = "resumes/update.html"
     success_url = reverse_lazy("resumes:index")
+
 
     def form_valid(self, form):
         resume = form.save(commit=False)
@@ -86,12 +90,11 @@ class ResumeDeleteView(DeleteView):
 
 
 class TotalListView(ListView):
-    template_name = "resumes/total.html"
-    context_object_name = "total_data"
+    template_name = 'resumes/total.html'
+    context_object_name = 'total_data'
 
     def get_queryset(self):
-        resume_id = self.kwargs["resume_id"]
-
+        resume_id = self.kwargs['resume_id']
         resume_data = Resume.objects.filter(resume_id=resume_id)
         education_data = Education.objects.filter(resume_id=resume_id)
         work_data = Work.objects.filter(resume_id=resume_id)

--- a/templates/companies/home.html
+++ b/templates/companies/home.html
@@ -2,7 +2,7 @@
 {% block content %}
 {% if user.is_authenticated %}
     <h1>Welcome, {{request.user}}!</h1>
-    <a href="{% url 'companies:detail' user.id %}">View Profile</a>
+    <a href="{% url 'companies:detail' user.company.id %}">View Profile</a>
     <br>
     <form action="{% url 'companies:logout' %}" method="post">
         {% csrf_token %}

--- a/templates/jobs/job.html
+++ b/templates/jobs/job.html
@@ -7,7 +7,7 @@
 <div class="flex">
     <form>
         {% csrf_token %}
-        <button type="button" hx-post="{% url 'jobs:setpublish' job.id %}" hx-swap="innerHTML" hx-target="#publish-{{ job.id }}" class="{% if job.is_published %}bg-blue-800 text-white{% else %}bg-blue-200{% endif %}">
+        <button type="button" hx-post="{% url 'jobs:publish' job.id %}" hx-swap="innerHTML" hx-target="#publish-{{ job.id }}" class="{% if job.is_published %}bg-blue-800 text-white{% else %}bg-blue-200{% endif %}">
             {{ job.is_published | yesno:"刊登中,已下架" }}
         </button>
     </form>

--- a/users/__init__.py
+++ b/users/__init__.py
@@ -1,0 +1,1 @@
+from . import rules

--- a/users/rules.py
+++ b/users/rules.py
@@ -1,0 +1,10 @@
+import rules
+
+@rules.predicate
+def is_user(custom_user):
+    if not custom_user.is_authenticated:
+        return False
+    return custom_user.user_type == 1
+
+
+rules.add_perm('user_can_show',is_user)

--- a/works/__init__.py
+++ b/works/__init__.py
@@ -1,0 +1,1 @@
+from . import rules

--- a/works/rules.py
+++ b/works/rules.py
@@ -1,0 +1,8 @@
+import rules
+
+@rules.predicate
+def is_work_user(user,work):
+    return user == work.resume.user
+
+def add_rule():
+    rules.add_rule('is_work_user',is_work_user)

--- a/works/views.py
+++ b/works/views.py
@@ -3,13 +3,15 @@ from .forms import WorkForm
 from .models import Work
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, ListView, UpdateView, DeleteView
+from django.contrib.auth.mixins import PermissionRequiredMixin
 
 
-class WorkCreateView(CreateView):
+class WorkCreateView(PermissionRequiredMixin,CreateView):
     model = Work
     form_class = WorkForm
-    template_name = "works/create.html"
-    success_url = reverse_lazy("resumes:work-show")
+    template_name = 'works/create.html'
+    success_url = reverse_lazy('resumes:work-show')
+    permission_required = "user_can_show"
 
     def form_valid(self, form):
         self.object = form.save()
@@ -17,10 +19,11 @@ class WorkCreateView(CreateView):
         return super().form_valid(form)
 
 
-class WorkListView(ListView):
+class WorkListView(PermissionRequiredMixin,ListView):
     model = Work
-    template_name = "works/index.html"
-    context_object_name = "works"
+    template_name = 'works/index.html'
+    context_object_name = 'works' 
+    permission_required = "user_can_show"
 
     def get_queryset(self):
         return Work.objects.filter(resume__user=self.request.user)
@@ -31,6 +34,7 @@ class WorkUpdateView(UpdateView):
     form_class = WorkForm
     template_name = "works/update.html"
     success_url = reverse_lazy("resumes:work-show")
+
 
     def form_valid(self, form):
         self.object = form.save()


### PR DESCRIPTION
#203

求職者

https://github.com/astrocamp/16th-EngiLink/assets/144601116/7543f44c-c9c8-4450-822f-6e95748731c5

公司

https://github.com/astrocamp/16th-EngiLink/assets/144601116/3f80f9e1-138d-4c42-81ce-52dcd6f45b96

目前可測試的網址

<公司身份>
無法看到這些頁面
companies/password_change/  (未登入者，會直接跳到login的頁面)
companies/<int:pk>/jobs/
companies/<int:pk>/create/
companies/<int:pk>/
(A公司不能看B公司的頁面，會跳出沒有權限)

無法觀看求職者頁面
users/
resumes/
resumes/create/

resumes/work/
resumes/work/show

resumes/edu/
resumes/edu/show

resumes/project/
resumes/project/show

<求職者>
無法看到這些頁面
companies/
companies/password_change/
companies/<int:pk>/jobs/
companies/<int:pk>/create/
companies/<int:pk>/


目前resume那整塊，需要跟pk連結的，等user和resume的路徑關聯串起來後，會再加入權限。另外開票。
jobs裡面的show、edit、delete的路徑，需要與公司的路徑做關聯後，會再加入權限。另外開票。
companies的DetailView的權限，會再另外開票處理。