### PR TITLE
修正navbar擋住的問題

### DIFF
--- a/templates/backend.html
+++ b/templates/backend.html
@@ -10,7 +10,9 @@
 </head>
 <body>
     {% include "shared/navbar.html" %}
-    {% block content %} 
-    {% endblock %}
+    <main class="pt-16">
+        {% block content %} 
+        {% endblock %}
+    </main>
 </body>
 </html>

--- a/templates/frontend.html
+++ b/templates/frontend.html
@@ -14,8 +14,10 @@
   </head>
   <body>
     {% include "shared/navbar.html" %} 
-    {% block content %} 
-    {% endblock %} 
+    <main class="pt-16">
+      {% block content %} 
+      {% endblock %} 
+    </main>
     {% if messages %} 
     {% for message in messages %}
     <script>


### PR DESCRIPTION
#229 

被navbar擋住的內容，都往下移動

公司
<img width="1455" alt="截圖 2024-05-25 下午1 33 36" src="https://github.com/astrocamp/16th-EngiLink/assets/144601116/cc4ffa52-f427-4bfb-b88e-9bc68e6572b0">
求職者
<img width="1462" alt="截圖 2024-05-25 下午1 34 51" src="https://github.com/astrocamp/16th-EngiLink/assets/144601116/848a96d1-d37c-420c-a022-a441d4b3052e">
