### PR TITLE
navbar和漢堡選單加上路徑和條件判斷

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -1,16 +1,16 @@
 {% extends "frontend.html" %}
 {% load static %}
 {% block content %}
-    <div class="flex flex-col justify-center items-center h-screen text-center lg:text-left lg:flex-row lg:items-center">
-        <div class="flex flex-col justify-center items-center lg:items-start lg:mr-8">
-            <img src="{% static 'img/logo.png' %}" class="w-20 lg:w-40 mb-4 mr-0 lg:mr-2">
-            <h1 class="text-blue-800 font-bold text-3xl lg:text-5xl">EngiLink</h1>
-            <h4 class="text-lg lg:text-xl mb-2 lg:mb-4">Connect me, just EngiLink</h4>
-            <h4 class="text-lg lg:text-xl mb-2 lg:mb-4">媒合英才，盡在EngiLink</h4>
-            <p class="italic font-light text-sm lg:text-base">Connecting top engineers and businesses worldwide. Join us now!</p>
-            <div class="flex flex-col items-center w-full mt-4 lg:flex-row lg:items-start lg:mt-8">
-                <button class="w-full lg:w-auto bg-blue-800 text-white px-6 lg:px-8 py-2 lg:py-4 rounded-full mb-2 lg:mb-0 lg:mr-4 hover:bg-blue-200 hover:text-black" onclick="location.href='{% url 'users:login' %}'">求職者登入</button>
-                <button class="w-full lg:w-auto bg-blue-800 text-white px-6 lg:px-8 py-2 lg:py-4 rounded-full hover:bg-blue-200 hover:text-black" onclick="location.href='{% url 'companies:login' %}'">公司登入</button>
+    <div class="flex justify-center items-center h-screen">
+        <div class="flex flex-col justify-center items-center">
+            <img src="{% static 'img/logo.png' %}" class="w-40 mb-4 mr-2">
+            <h1 class="text-blue-800 font-bold text-5xl">EngiLink</h1>
+            <h4 class="text-xl mb-4">Connect me, just EngiLink</h4>
+            <h4 class="text-xl mb-4">媒合英才，盡在EngiLink</h4>
+            <p class="italic font-light">Connecting top engineers and businesses worldwide. Join us now!</p>
+            <div class="flex">
+                <button class="bg-blue-800 text-white px-8 py-4 rounded-full mt-8 mr-4 hover:bg-blue-200 hover:text-black" onclick="location.href='{% url 'users:login' %}'">求職者登入</button>
+                <button class="bg-blue-800 text-white px-8 py-4 rounded-full mt-8 hover:bg-blue-200 hover:text-black" onclick="location.href='{% url 'companies:login' %}'">公司登入</button>
             </div>
         </div>
         <div class="hidden lg:block">

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -73,8 +73,12 @@
         <!-- 漢堡按鈕選單內容 -->
         <nav class="md:hidden" aria-label="Global" id="mobile-menu" :hidden='!openMenu' md:hidden>
             <div class="px-2 pt-2 pb-3 space-y-1">
-                <a href="#" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white" aria-current="page">我的履歷</a>
-                <a href="#" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white">我的職缺</a>
+                {% if request.user.user_type == 1 %}
+                <a href="{% url 'resumes:index' %}" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white" aria-current="page">我的履歷</a>
+                {% else %}
+                <a href="{% url 'users:login' %}" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white" aria-current="page">我的履歷</a>
+                {% endif %}
+                <a href="{% url 'users:collect' %}" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white">我的收藏</a>
                 <a href="#" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white">應徵紀錄</a>
                 <a href="#" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white">個人設定</a>
                 <form

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -56,9 +56,9 @@
                         {% endif %}
                         <a href="{% url 'users:collect' %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-1">我的收藏</a>
                         {% if request.user.user_type == 1 %}
-                            <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
+                            <a href="{% url 'users:applications' user.id %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
                         {% else %}
-                            <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
+                            <a href="{% url 'users:login' %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
                         {% endif %}
                         <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">個人設定</a>
                         <form

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -4,7 +4,12 @@
     <header class="fixed top-0 w-full bg-white shadow-lg">
         <div class="flex items-center justify-between h-16 px-2 mx-auto md:flex md:justify-between md:items-center max-w-7xl sm:px-4">
             <div class="items-center flex-shrink-0">
-                <a href="#"><img src="{% static 'img/logo.png' %}" class="inline h-10"></a>
+                {% if request.user.user_type == 2 %}
+                    <a href="{% url 'companies:home' %}">
+                {% else %}
+                    <a href="{% url 'users:home' %}">
+                {% endif %}
+                    <img src="{% static 'img/logo.png' %}" class="inline h-10">
             </div>
             <div>
                 <ul class="hidden md:flex md:items-center">
@@ -15,7 +20,11 @@
                         <a href="{% url 'jobs:job_list' %}" class="text-sm duration-500 hover:text-blue-600">找工作</a>
                     </li>
                     <li class="px-1">
-                        <a href="#" class="text-sm duration-500 hover:text-blue-600 ">履歷工具</a>
+                        {% if not request.user.is_authenticated or request.user.user_type != 1 %}
+                            <a href="{% url 'users:login' %}" class="text-sm duration-500 hover:text-blue-600">履歷工具</a>
+                        {% else %}
+                            <a href="{% url 'resumes:index' %}" class="text-sm duration-500 hover:text-blue-600">履歷工具</a>
+                        {% endif %}
                     </li>
                 </ul>
             </div>
@@ -23,9 +32,9 @@
                 <button type="button" class="inline-flex items-center justify-center p-2 text-blue-800 rounded-md hover:bg-blue-200 hover:text-white md:hidden" aria-controls="mobile-menu" aria-expanded="false" @click="openMenu = !openMenu">
                     <span class="sr-only">Open menu</span>
                     <svg class="block w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                     </svg>
-                  </button>
+                    </button>
             </div>
             <div class="hidden md:flex">
                 <div>
@@ -40,9 +49,17 @@
                     </button>
                     <!-- 選單內容 -->
                     <div class="absolute right-0 z-10 w-48 py-1 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button" tabindex="-1" :hidden='!openMenu' md:hidden>
-                        <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-0">我的履歷</a>
+                        {% if request.user.user_type == 1 %}
+                            <a href="{% url 'resumes:index' %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-0">我的履歷</a>
+                        {% else %}
+                            <a href="{% url 'users:login' %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-0">我的履歷</a>
+                        {% endif %}
                         <a href="{% url 'users:collect' %}" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-1">我的收藏</a>
-                        <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
+                        {% if request.user.user_type == 1 %}
+                            <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
+                        {% else %}
+                            <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">應徵紀錄</a>
+                        {% endif %}
                         <a href="#" class="block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="user-menu-item-2">個人設定</a>
                         <form
                             action="{% url 'users:logout' %}" method="post">
@@ -73,7 +90,7 @@
             <div class="flex items-center justify-between h-16 px-2 mx-auto md:flex md:justify-between md:items-center max-w-7xl sm:px-4">
                 <!-- logo -->
                 <div class="items-center flex-shrink-0">
-                    <a href="#"><img src="{% static 'img/logo.png' %}" class="inline h-10"></a>
+                    <a href="{% url 'home'%}"><img src="{% static 'img/logo.png' %}" class="inline h-10"></a>
                 </div>
     
                 <div>
@@ -85,7 +102,7 @@
                             <a href="{% url 'jobs:job_list' %}" class="text-sm duration-500 hover:text-blue-600">找工作</a>
                         </li>
                         <li class="px-1">
-                            <a href="#" class="text-sm duration-500 hover:text-blue-600 ">履歷工具</a>
+                            <a href="{% url 'users:login' %}" class="text-sm duration-500 hover:text-blue-600 ">履歷工具</a>
                         </li>
                     </ul>
                 </div>
@@ -99,7 +116,7 @@
                 </div>
             </div>
             <!-- 漢堡按鈕選單內容 -->
-            <nav class="lg:hidden" aria-label="Global" id="mobile-menu"     :hidden='!openMenu' md:hidden>
+            <nav class="lg:hidden" aria-label="Global" id="mobile-menu" :hidden='!openMenu' md:hidden>
             <div class="px-2 pt-2 pb-3 space-y-1">
               <a href="#" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white" aria-current="page">找公司</a>
               <a href="{% url 'jobs:job_list' %}" class="block px-3 py-2 text-base font-medium text-gray-500 rounded-md hover:bg-gray-700 hover:text-white">找工作</a>


### PR DESCRIPTION
未登入：
點logo回首頁
點履歷工具回求職者登入頁面

登入後：
點logo求職者和公司方停留在進來的頁面
求職者登入後點選履歷工具到創建履歷
公司方登入後點選履歷工具回求職者登入頁面

漢堡選單『我的履歷』
求職者登入後點選履歷工具到創建履歷
公司方登入後點選履歷工具回求職者登入頁面


待 #221 通過後再新增 漢堡選單『應徵紀錄』路徑和判斷
