### PR TITLE
公司資料輸入欄位新增地址、簡介、類別、橫幅圖片、logo #222

### DIFF
--- a/companies/forms.py
+++ b/companies/forms.py
@@ -26,10 +26,15 @@ class CompanyUpdateForm(UserChangeForm):
     tin = forms.CharField(max_length=8)
     user_name = forms.CharField(max_length=100)
     tel = forms.CharField(max_length=11)
+    address = forms.CharField(max_length=250)
+    description = forms.CharField(widget=forms.Textarea)
+    type = forms.CharField(max_length=50)
+    banner = forms.ImageField(required=False)
+    logo = forms.ImageField(required=False)
 
     class Meta:
         model = CustomUser
-        fields = ["username", "email", "company_name", "tin", "user_name", "tel"]
+        fields = ["username", "email", "company_name", "tin", "user_name", "tel", "address", "description", "type", "banner", "logo"]
 
     def __init__(self, *args, **kwargs):
         super(CompanyUpdateForm, self).__init__(*args, **kwargs)
@@ -41,6 +46,11 @@ class CompanyUpdateForm(UserChangeForm):
         self.fields["tin"].label = "統一編號"
         self.fields["user_name"].label = "聯絡人"
         self.fields["tel"].label = "聯絡電話"
+        self.fields["address"].label = "地址"
+        self.fields["description"].label = "簡介"
+        self.fields["type"].label = "類型"
+        self.fields["banner"].label = "橫幅"
+        self.fields["logo"].label = "Logo"
 
         if "instance" in kwargs:
             user = kwargs["instance"]
@@ -50,6 +60,11 @@ class CompanyUpdateForm(UserChangeForm):
                 self.fields["tin"].initial = company.tin
                 self.fields["user_name"].initial = company.user_name
                 self.fields["tel"].initial = company.tel
+                self.fields["address"].initial = company.address
+                self.fields["description"].initial = company.description
+                self.fields["type"].initial = company.type
+                self.fields["banner"].initial = company.banner
+                self.fields["logo"].initial = company.logo
 
     def save(self, commit=True):
         user = super().save(commit=False)
@@ -61,6 +76,11 @@ class CompanyUpdateForm(UserChangeForm):
                     "tin": self.cleaned_data["tin"],
                     "user_name": self.cleaned_data["user_name"],
                     "tel": self.cleaned_data["tel"],
+                    "address": self.cleaned_data["address"],
+                    "description": self.cleaned_data["description"],
+                    "type": self.cleaned_data["type"],
+                    "banner": self.cleaned_data["banner"],
+                    "logo": self.cleaned_data["logo"],
                 },
             )
             if commit:

--- a/companies/views.py
+++ b/companies/views.py
@@ -122,6 +122,23 @@ class CompanyUpdateView(PermissionRequiredMixin,LoginRequiredMixin, UpdateView):
 
     def get_queryset(self):
         return CustomUser.objects.filter(user_type=2, id=self.request.user.id)
+    
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        company, created = Company.objects.get_or_create(custom_user=self.object)
+        company.company_name = form.cleaned_data['company_name']
+        company.tin = form.cleaned_data['tin']
+        company.user_name = form.cleaned_data['user_name']
+        company.tel = form.cleaned_data['tel']
+        company.address = form.cleaned_data['address']
+        company.description = form.cleaned_data['description']
+        company.type = form.cleaned_data['type']
+        if 'banner' in form.cleaned_data and form.cleaned_data['banner']:
+            company.banner = form.cleaned_data['banner']
+        if 'logo' in form.cleaned_data and form.cleaned_data['logo']:
+            company.logo = form.cleaned_data['logo']
+        company.save()
+        return response
 
 
 class CompanyPasswordChangeView(PermissionRequiredMixin,PasswordChangeView):

--- a/companies/views.py
+++ b/companies/views.py
@@ -122,24 +122,6 @@ class CompanyUpdateView(PermissionRequiredMixin,LoginRequiredMixin, UpdateView):
 
     def get_queryset(self):
         return CustomUser.objects.filter(user_type=2, id=self.request.user.id)
-    
-    def form_valid(self, form):
-        response = super().form_valid(form)
-        company, created = Company.objects.get_or_create(custom_user=self.object)
-        company.company_name = form.cleaned_data['company_name']
-        company.tin = form.cleaned_data['tin']
-        company.user_name = form.cleaned_data['user_name']
-        company.tel = form.cleaned_data['tel']
-        company.address = form.cleaned_data['address']
-        company.description = form.cleaned_data['description']
-        company.type = form.cleaned_data['type']
-        if 'banner' in form.cleaned_data and form.cleaned_data['banner']:
-            company.banner = form.cleaned_data['banner']
-        if 'logo' in form.cleaned_data and form.cleaned_data['logo']:
-            company.logo = form.cleaned_data['logo']
-        company.save()
-        return response
-
 
 class CompanyPasswordChangeView(PermissionRequiredMixin,PasswordChangeView):
     template_name="companies/password_change_form.html"

--- a/templates/companies/detail.html
+++ b/templates/companies/detail.html
@@ -7,5 +7,22 @@
     <p>統一編號: {{ user.company.tin }}</p>
     <p>聯絡人: {{ user.company.user_name }}</p>
     <p>聯絡電話: {{ user.company.tel }}</p>
+    <p>地址: {{ user.company.address }}</p>
+    <p>簡介: {{ user.company.description }}</p>
+    <p>類型: {{ user.company.type }}</p>
+    <p>橫幅: 
+        {% if user.company.banner %}
+            <img src="{{ user.company.banner.url }}" alt="Company Banner">
+        {% else %}
+            <span>No banner available</span>
+        {% endif %}
+    </p>
+    <p>Logo: 
+        {% if user.company.logo %}
+            <img src="{{ user.company.logo.url }}" alt="Company Logo">
+        {% else %}
+            <span>No logo available</span>
+        {% endif %}
+    </p>
 <a href="{% url 'companies:update' user.id%}">編輯</a>
 {% endblock %}

--- a/templates/companies/update.html
+++ b/templates/companies/update.html
@@ -1,39 +1,39 @@
 {% extends 'backend.html' %} 
 {% block content %}
-<div class="container mx-auto flex flex-col justify-center items-center max-w-lg pt-16">
-    <div class='header-bar flex justify-center items-center bg-blue-600 text-white p-4 rounded-t-md w-full'>
+<div class="container flex flex-col items-center justify-center max-w-lg pt-16 mx-auto">
+    <div class='flex items-center justify-center w-full p-4 text-white bg-blue-600 header-bar rounded-t-md'>
         <h2>公司資訊</h2>
     </div>
-    <div class="task-items-wrapper flex flex-col w-full">
-        <div class="task-wrapper flex justify-center items-center py-4 px-6 bg-white border-t border-gray-300 w-full">
+    <div class="flex flex-col w-full task-items-wrapper">
+        <div class="flex items-center justify-center w-full px-6 py-4 bg-white border-t border-gray-300 task-wrapper">
             <form method="post" class="w-full max-w-lg">
                 {% csrf_token %}
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">帳號：</label>
-                    <input type="text" name="username" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.username.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">帳號：</label>
+                    <input type="text" name="username" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.username.value }}">
                 </div>
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">公司信箱：</label>
-                    <input type="text" name="email" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.email.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">公司信箱：</label>
+                    <input type="text" name="email" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.email.value }}">
                 </div>
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">公司名稱：</label>
-                    <input type="text" name="company_name" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.company_name.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">公司名稱：</label>
+                    <input type="text" name="company_name" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.company_name.value }}">
                 </div>
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">統一編號：</label>
-                    <input type="text" name="tin" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.tin.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">統一編號：</label>
+                    <input type="text" name="tin" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.tin.value }}">
                 </div>
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">聯絡人：</label>
-                    <input type="text" name="user_name" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.user_name.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">聯絡人：</label>
+                    <input type="text" name="user_name" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.user_name.value }}">
                 </div>
                 <div class="mb-4">
-                    <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">聯絡電話：</label>
-                    <input type="text" name="tel" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ form.tel.value }}">
+                    <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">聯絡電話：</label>
+                    <input type="text" name="tel" required id="id_username" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline" value="{{ form.tel.value }}">
                 </div>
                 <div class="flex justify-end px-1">
-                    <button type="submit" class="button border border-blue-600 bg-white text-blue-600 px-4 py-2 hover:bg-blue-600 hover:text-white rounded">更新</button>
+                    <button type="submit" class="px-4 py-2 text-blue-600 bg-white border border-blue-600 rounded button hover:bg-blue-600 hover:text-white">更新</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
在公司資料輸入欄位新增地址、簡介、類別、橫幅圖片、logo ，輸入的資料會反應到找公司的頁面上，但找工作的職缺卡片沒能顯示出公司橫幅圖片與logo，會再開票修改 (#235)

在navbar連結失效問題修復前，請用連結找頁面：

- 找公司：http://127.0.0.1:8000/companies/list/
- 找工作：http://127.0.0.1:8000/jobs/list/ 

<img width="418" alt="截圖 2024-05-25 晚上9 07 34" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/a83516aa-4b31-4bbb-be2c-a8c6b2e70a42">


找公司卡片有預設上傳的圖片自動縮圖成符合卡片的大小
<img width="422" alt="截圖 2024-05-25 晚上9 29 25" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/cb8546fb-2460-4f49-91f6-dcb823726356">

上傳圖片會存入資料庫裡：
<img width="1304" alt="截圖 2024-05-25 晚上9 16 18" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/7a685556-839c-45af-b127-8b2a555badd0">


測試錄影（文字已有先傳好，這段是重新測試上傳圖片的功能）：

https://github.com/astrocamp/16th-EngiLink/assets/149367532/e589fa19-33f1-4b29-89eb-6dc5a89d8978


