### PR TITLE
取消找工作的公司橫幅與logo在views的註解

### DIFF
--- a/jobs/views.py
+++ b/jobs/views.py
@@ -93,8 +93,8 @@ class JobListView(ListView):
             job_info = {
                 'title': job.title,
                 'company_name': company.company_name,
-                # 'company_logo_url': company.logo.url if company.logo else '',
-                # 'company_banner_url': company.banner.url if company.banner else '',
+                'company_logo_url': company.logo.url if company.logo else '',
+                'company_banner_url': company.banner.url if company.banner else '',
                 'address': job.address,
                 'salary': job.salary,
                 'description': job.description,


### PR DESCRIPTION
取消原先在找工作的公司橫幅與logo在jobs/views.py的註解，使公司圖片與logo可以顯現出來


<img width="1059" alt="截圖 2024-05-25 晚上10 37 58" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/7b417dd8-cbc0-433f-b7c4-c2e1b3d68d82">
