### PR TITLE
公司刊登職缺頁面切版, label修正

### DIFF
--- a/templates/jobs/index.html
+++ b/templates/jobs/index.html
@@ -1,14 +1,25 @@
 {% extends "backend.html" %}
 {% block content %}
-    <h1 class="bg-blue-500 py-2 px-2">職缺列表</h1>
-        <section class="flex">
-            {% for job in jobs %}
-                <div id="publish-{{ job.id }}">
-                    {% include "jobs/job.html"%}
-                </div>   
-            {% endfor %}
+    <div class="pt-18">
+        <div class="fixed z-10 w-full bg-white top-16">
+            <h1 class="px-2 py-2 bg-blue-500">職缺列表</h1>
+            <div class="flex justify-center mt-1 space-x-2">
+                <button class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">
+                    <a href="{% url 'companies:home' %}">會員系統</a>
+                </button>
+                <button class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">
+                    <a href="{% url 'companies:jobs_create' user.company.id %}">刊登職缺</a>
+                </button>
+            </div>
+        </div>
+        <section class="container flex flex-wrap justify-center px-4 py-4 mx-auto mt-20">
+            <div class="flex flex-wrap justify-start w-full max-w-screen-lg">
+                {% for job in jobs %}
+                    <div id="publish-{{ job.id }}" class="w-full p-4 sm:w-full md:w-1/2 lg:w-1/2 xl:w-1/2">
+                        {% include "jobs/job.html"%}
+                    </div>   
+                {% endfor %}
+            </div>
         </section>
-        
-    <button><a href="{% url 'companies:home' %}">會員系統</a></button>
-    <button><a href="{% url 'companies:jobs_create' user.company.id %}">刊登職缺</a></button>
+    </div>
 {% endblock %}

--- a/templates/jobs/index.html
+++ b/templates/jobs/index.html
@@ -1,7 +1,7 @@
 {% extends "backend.html" %}
 {% block content %}
     <div class="pt-18">
-        <div class="fixed z-10 w-full bg-white top-16">
+        <div class="fixed w-full bg-white top-16">
             <h1 class="px-2 py-2 bg-blue-500">職缺列表</h1>
             <div class="flex justify-center mt-1 space-x-2">
                 <button class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600">

--- a/templates/jobs/job.html
+++ b/templates/jobs/job.html
@@ -1,17 +1,23 @@
-<p>職位名稱：{{ job.title }}</p>
-<p>需求人數：{{ job.openings }}</p>
-<p>工作年資：{{ job.experience }}</p>
-<p>工作經驗：{{ job.salary }}</p>
-<p>工作地點：{{ job.address }}</p>
-<p>工作描述：{{ job.description }}</p>
-<div class="flex">
-    <form>
-        {% csrf_token %}
-        <button type="button" hx-post="{% url 'jobs:publish' job.id %}" hx-swap="innerHTML" hx-target="#publish-{{ job.id }}" class="{% if job.is_published %}bg-blue-800 text-white{% else %}bg-blue-200{% endif %}">
-            {{ job.is_published | yesno:"刊登中,已下架" }}
-        </button>
-    </form>
-    <button><a href="{% url 'jobs:show' job.id %}">編輯</a></button>
+<div class="p-6 bg-white rounded-lg shadow-md">
+    <h2 class="mb-4 text-2xl font-bold">{{ job.title }}</h2>
+    <p class="mb-2"><span class="font-semibold">需求人數：</span>{{ job.openings }}</p>
+    <p class="mb-2"><span class="font-semibold">工作年資：</span>{{ job.experience }}</p>
+    <p class="mb-2"><span class="font-semibold">工作薪資：</span>{{ job.salary }}</p>
+    <p class="mb-2"><span class="font-semibold">工作地點：</span>{{ job.address }}</p>
+    <p class="mb-4"><span class="font-semibold">工作描述：</span>{{ job.description }}</p>
+    <div class="flex items-center justify-between">
+        <form class="flex-1">
+            {% csrf_token %}
+            <button type="button"
+                    hx-post="{% url 'jobs:setpublish' job.id %}"
+                    hx-swap="innerHTML"
+                    hx-target="#publish-{{ job.id }}"
+                    class="w-full py-2 px-4 rounded-md {% if job.is_published %}bg-blue-800 text-white{% else %}bg-blue-200{% endif %} hover:bg-blue-600">
+                {{ job.is_published | yesno:"刊登中,已下架" }}
+            </button>
+        </form>
+        <div class="ml-4">
+            <a href="{% url 'jobs:show' job.id %}" class="px-4 py-2 text-gray-800 bg-gray-300 border-2 border-gray-300 rounded-md hover:bg-gray-400">編輯</a>
+        </div>
+    </div>
 </div>
-
-

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -1,7 +1,7 @@
 {% load static %}
 <div x-data="{ openMenu : false }">
     {% if user.is_authenticated %}
-    <header class="fixed top-0 w-full bg-white shadow-lg">
+    <header class="fixed top-0 z-20 w-full bg-white shadow-lg">
         <div class="flex items-center justify-between h-16 px-2 mx-auto md:flex md:justify-between md:items-center max-w-7xl sm:px-4">
             <div class="items-center flex-shrink-0">
                 {% if request.user.user_type == 2 %}


### PR DESCRIPTION
1. 已修正原本工作薪資顯示為工作經驗的label問題
2. 將公司刊登職缺的頁面進行切版美化，因考量文字內容可能會比較多，三張呈現會很擠，所以原本RWD設計大螢幕三張卡片一行，改為一行兩張
3. 有RWD設計
4. 使用發現會員系統跟職缺刊登按鈕會隨著職缺資料增加而往下擠，會增加使用不便性，所以改成會員系統跟職缺刊登按鈕固定在上方，且不隨著網頁捲動而改變位置
5. 按鈕顏色跟變色效果，之後可再統一調整（以前有開票#83），使網頁外觀設定一致性

網頁：
<img width="1163" alt="截圖 2024-05-26 晚上7 19 03" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/6c5e5eae-cc68-4dbd-aa13-d8910cd5eb1a">

<img width="1166" alt="截圖 2024-05-26 晚上7 19 11" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/cae5c324-6376-49d1-95bc-8a818d995b47">

手機：

<img width="498" alt="截圖 2024-05-26 晚上7 37 04" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/7b41ed9c-42de-4375-b87b-35e2b0135ad1">

<img width="494" alt="截圖 2024-05-26 晚上7 37 15" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/e3b48054-47b2-44f4-806c-fbfb7ee54c56">


測試錄影：

https://github.com/astrocamp/16th-EngiLink/assets/149367532/1e3e04d0-78d2-4121-b52c-8c9a5d36b038

RWD：

https://github.com/astrocamp/16th-EngiLink/assets/149367532/fd11e51d-a44f-463b-8a75-00a6fa85a67e


