### PR TITLE
職缺刊登刪除頁面跳轉

### DIFF
--- a/jobs/views.py
+++ b/jobs/views.py
@@ -71,16 +71,12 @@ class EditView(UpdateView):
         self.success_url = f"/companies/{pk}/jobs/"
         return super().form_valid(form)
 
-
 class JobDeleteView(DeleteView):
     model = Job
-    success_url = "companies/<pk>/jobs/"
-
-    def form_valid(self, form):
-        pk = self.kwargs.get("pk")
-        self.success_url = f"/companies/{pk}/jobs/"
-        return super().form_valid(form)
-
+    
+    def get_success_url(self):
+        pk = self.object.company.pk
+        return reverse('companies:jobs', kwargs={'pk': pk})
 
 class PublishView(DetailView):
     model=Job


### PR DESCRIPTION
補上公司刪除刊登的職缺訊息後，跳回職缺畫面
（原本沒設定刪除後的跳轉頁面，會跳出page not found，但訊息有刪除掉）

修改後：

https://github.com/astrocamp/16th-EngiLink/assets/149367532/369bdcb3-8e7e-41b5-b6cc-4e79282410c3




原本的：

https://github.com/astrocamp/16th-EngiLink/assets/149367532/beb25066-13e7-45eb-97ba-1294f285cf08









