### PR TITLE
增加註冊條件提示句

### DIFF
--- a/templates/companies/register.html
+++ b/templates/companies/register.html
@@ -1,31 +1,31 @@
 {% extends 'backend.html' %}
 {% block content %}
-    <div class="container mx-auto flex flex-col justify-center items-center max-w-lg pt-16">
-        <div class='header-bar flex justify-center items-center bg-blue-600 text-white p-4 rounded-t-md w-full'>
+    <div class="container flex flex-col items-center justify-center max-w-lg pt-16 mx-auto">
+        <div class='flex items-center justify-center w-full p-4 text-white bg-blue-600 header-bar rounded-t-md'>
             <h2>公司註冊</h2>
         </div>
-        <div class="task-items-wrapper flex flex-col w-full">
-            <div class="task-wrapper flex justify-center items-center py-4 px-6 bg-white border-t border-gray-300 w-full">
+        <div class="flex flex-col w-full task-items-wrapper">
+            <div class="flex items-center justify-center w-full px-6 py-4 bg-white border-t border-gray-300 task-wrapper">
                 <form method="post" action="{% url 'companies:register' %}" class="w-full max-w-lg">
                     {% csrf_token %}
                     <div class="mb-4">
-                        <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">用戶名：</label>
-                        <input type="text" name="username" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">用戶名：</label>
+                        <input type="text" name="username" required id="id_username" placeholder="請輸入4-20個字符" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-4">
-                        <label for="id_email" class="block text-gray-700 text-sm font-bold mb-2">電子郵件：</label>
-                        <input type="email" name="email" required id="id_email" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_email" class="block mb-2 text-sm font-bold text-gray-700">電子郵件：</label>
+                        <input type="email" name="email" required id="id_email" placeholder="請輸入有效的電子郵件地址" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-4">
-                        <label for="id_password1" class="block text-gray-700 text-sm font-bold mb-2">密碼：</label>
-                        <input type="password" name="password1" required id="id_password1" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_password1" class="block mb-2 text-sm font-bold text-gray-700">密碼：</label>
+                        <input type="password" name="password1" required id="id_password1" placeholder="至少8個字符，包含大小寫字母及數字" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-6">
-                        <label for="id_password2" class="block text-gray-700 text-sm font-bold mb-2">確認密碼：</label>
-                        <input type="password" name="password2" required id="id_password2" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_password2" class="block mb-2 text-sm font-bold text-gray-700">確認密碼：</label>
+                        <input type="password" name="password2" required id="id_password2" placeholder="請再次輸入同樣的密碼" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="flex justify-end">
-                        <button type="submit" class="button border border-blue-600 bg-white text-blue-600 px-4 py-2 hover:bg-blue-600 hover:text-white rounded">提交</button>
+                        <button type="submit" class="px-4 py-2 text-blue-600 bg-white border border-blue-600 rounded button hover:bg-blue-600 hover:text-white">提交</button>
                     </div>
                 </form>
             </div>

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -1,31 +1,31 @@
 {% extends 'frontend.html' %}
 {% block content %}
-    <div class="container mx-auto flex flex-col justify-center items-center max-w-lg pt-16">
-        <div class='header-bar flex justify-center items-center bg-blue-600 text-white p-4 rounded-t-md w-full'>
+    <div class="container flex flex-col items-center justify-center max-w-lg pt-16 mx-auto">
+        <div class='flex items-center justify-center w-full p-4 text-white bg-blue-600 header-bar rounded-t-md'>
             <h2>註冊</h2>
         </div>
-        <div class="task-items-wrapper flex flex-col w-full">
-            <div class="task-wrapper flex justify-center items-center py-4 px-6 bg-white border-t border-gray-300 w-full">
+        <div class="flex flex-col w-full task-items-wrapper">
+            <div class="flex items-center justify-center w-full px-6 py-4 bg-white border-t border-gray-300 task-wrapper">
                 <form method="post" action="{% url 'users:register' %}" class="w-full max-w-lg">
                     {% csrf_token %}
                     <div class="mb-4">
-                        <label for="id_username" class="block text-gray-700 text-sm font-bold mb-2">用戶名：</label>
-                        <input type="text" name="username" required id="id_username" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_username" class="block mb-2 text-sm font-bold text-gray-700">用戶名：</label>
+                        <input type="text" name="username" required id="id_username" placeholder="請輸入4-20個字符" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-4">
-                        <label for="id_email" class="block text-gray-700 text-sm font-bold mb-2">電子郵件：</label>
-                        <input type="email" name="email" required id="id_email" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_email" class="block mb-2 text-sm font-bold text-gray-700">電子郵件：</label>
+                        <input type="email" name="email" required id="id_email" placeholder="請輸入有效的電子郵件地址" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-4">
-                        <label for="id_password1" class="block text-gray-700 text-sm font-bold mb-2">密碼：</label>
-                        <input type="password" name="password1" required id="id_password1" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_password1" class="block mb-2 text-sm font-bold text-gray-700">密碼：</label>
+                        <input type="password" name="password1" required id="id_password1" placeholder="至少8個字符，包含大小寫字母及數字" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="mb-6">
-                        <label for="id_password2" class="block text-gray-700 text-sm font-bold mb-2">確認密碼：</label>
-                        <input type="password" name="password2" required id="id_password2" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        <label for="id_password2" class="block mb-2 text-sm font-bold text-gray-700">確認密碼：</label>
+                        <input type="password" name="password2" required id="id_password2" placeholder="請再次輸入同樣的密碼" class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline">
                     </div>
                     <div class="flex justify-end">
-                        <button type="submit" class="button border border-blue-600 bg-white text-blue-600 px-4 py-2 hover:bg-blue-600 hover:text-white rounded">提交</button>
+                        <button type="submit" class="px-4 py-2 text-blue-600 bg-white border border-blue-600 rounded button hover:bg-blue-600 hover:text-white">提交</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
因後來郁軒做同樣的功能(#284 )，且有修改公司註冊版面顏色，所以選用郁軒做的

已增加註冊條件提示：

使用者註冊：
<img width="698" alt="截圖 2024-05-27 晚上10 29 23" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/4c236aeb-ee10-44c9-a178-5a9d610d9d10">

公司註冊：
<img width="722" alt="截圖 2024-05-27 晚上10 29 15" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/ced841c2-1803-4573-aaf0-54138d377c47">

但我們好像沒設定註冊條件？只能先暫時用通用型的做提示句，看之後是否要開票設定註冊條件？