### PR TITLE
users/home.html元素連結＋搜尋功能（公司）

### DIFF
--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -44,9 +44,9 @@
                             {% else %}
                                 <img src="/static/images/default_logo.jpg" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
                             {% endif %}
-                            <div>
-                                <h3 class="text-lg font-semibold">{{ job.title }}</h3>
-                                <p class="font-semibold text-blue-600">{{ job.company.company_name }}</p>
+                            <div class="overflow-hidden whitespace-nowrap">
+                                <h3 class="text-lg font-semibold truncate">{{ job.title }}</h3>
+                                <p class="font-semibold text-blue-600 truncate">{{ job.company.company_name }}</p>
                             </div>
                         </div>
                         <div class="flex items-center justify-between space-x-2">

--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -2,29 +2,18 @@
 {% load humanize %}
 {% block content %}
 {% if user.is_authenticated %}
-    <div class="flex flex-col min-h-screen">
-        <header class="sticky z-10 w-full py-8 text-center bg-blue-50 top-16">
-            <div class="container px-4 mx-auto">
-                <h1 class="text-2xl font-bold">拓展求職視野，尋找理想工作</h1>
-                <div class="flex flex-wrap justify-center mt-6">
-                    <form action="{% url 'users:home' %}" method="get" class="flex w-full md:w-2/3">
-                        <input type="text" name="q" placeholder="找工作、公司..." class="flex-grow p-2 border border-gray-300 rounded-l-lg focus:outline-none focus:border-indigo-500" value="{{ request.GET.q|default:'' }}"/>
-                        <button type="submit" class="p-2 text-white bg-blue-500 rounded-r-lg">搜尋</button>
-                        {% if request.GET.q %}
-                            <a href="{% url 'users:home' %}" class="p-2 ml-2 text-white bg-red-500 rounded-lg">取消搜尋</a>
-                        {% endif %}
-                    </form>
-                </div>
+    <header class="sticky z-10 w-full py-8 text-center bg-blue-50 top-16">
+        <div class="container px-4 mx-auto">
+            <h1 class="text-2xl font-bold">拓展求職視野，尋找理想工作</h1>
+            <div class="flex flex-wrap justify-center mt-6">
+                <form action="{% url 'users:home' %}" method="get" class="flex w-full md:w-2/3">
+                    <input type="text" name="q" placeholder="找工作、公司..." class="flex-grow p-2 border border-gray-300 rounded-l-lg focus:outline-none focus:border-indigo-500" value="{{ request.GET.q|default:'' }}"/>
+                    <button type="submit" class="p-2 text-white bg-blue-500 rounded-r-lg">搜尋</button>
+                    {% if request.GET.q %}
+                        <a href="{% url 'users:home' %}" class="p-2 ml-2 text-white bg-red-500 rounded-lg">取消搜尋</a>
+                    {% endif %}
+                </form>
             </div>
-<<<<<<< HEAD
-        </header>
-        <div class="container px-4 py-8 mx-auto">
-            <section class="mb-12">
-                <h2 class="mb-4 text-2xl font-bold">熱門職缺</h2>
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-                    {% for job in jobs %}
-                        <div class="relative p-4 bg-white rounded-lg shadow hover:shadow-xl">
-=======
         </div>
     </header>
     <div class="container px-4 py-8 mx-auto">
@@ -104,99 +93,6 @@
                             {% endif %}
                             <h2 class="text-xl font-semibold truncate">{{ company.company_name }}</h2>
                         </div>
-<<<<<<< HEAD
-                        <div class="flex-grow p-4">
->>>>>>> 96a41dd (feat: add icon)
-                            <div class="flex items-center mb-4">
-                                {% if job.company.logo %}
-                                    <img src="{{ job.company.logo.url }}" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
-                                {% else %}
-                                    <img src="/static/images/default_logo.jpg" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
-                                {% endif %}
-                                <div>
-                                    <h3 class="text-lg font-semibold">{{ job.title }}</h3>
-                                    <p class="font-semibold text-blue-600">{{ job.company.company_name }}</p>
-                                </div>
-                            </div>
-                            <div class="flex items-center space-x-2">
-                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
-                                    <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
-                                </svg>
-                                <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
-                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
-                                    <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/>
-                                </svg>
-                                <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
-                            </div>
-                            <div class="absolute flex flex-col items-center justify-end space-y-2 bottom-4 right-4">
-                                <form class="inline" action="{% url 'users:collect' %}" method="post">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="job_id" value="{{ job.id }}">
-                                    <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
-                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
-                                            <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
-                                        </svg>
-                                    </button>
-                                </form>
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
-            </section>
-            <section>
-                <h2 class="mb-4 text-2xl font-bold">推薦公司</h2>
-                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-                    {% for company in companies %}
-                        <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
-                            <div class="relative p-2">
-                                {% if company.banner %}
-                                    <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
-                                        <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
-                                    </div>
-                                {% else %}
-                                    <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
-                                        <img src="/static/images/default_banner.jpg" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
-                                    </div>
-                                {% endif %}
-                            </div>
-                            <div class="flex-grow p-4">
-                                <div class="flex items-center mb-4">
-                                    {% if company.logo %}
-                                        <img src="{{ company.logo.url }}" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
-                                    {% else %}
-                                        <img src="/static/images/default_logo.jpg" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
-                                    {% endif %}
-                                    <h2 class="text-xl font-semibold truncate">{{ company.company_name }}</h2>
-                                </div>
-                                <div class="card-description min-h-[3rem]">
-                                    <p class="text-gray-600 line-clamp-3">{{ company.description }}</p>
-                                </div>
-                            </div>
-                            <div class="flex-shrink-0 p-4">
-                                <div class="flex items-end justify-between">
-                                    <div class="flex items-center space-x-2">
-                                        <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
-                                            <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
-                                        </svg>
-                                        <p class="flex items-center text-xs text-gray-600">{{ company.address|slice:":3" }}</p>
-                                        <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
-                                            <path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/>
-                                        </svg>
-                                        <p class="flex items-center text-xs text-gray-600">{{ company.type }}</p>
-                                    </div>
-                                    <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
-                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
-                                            <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
-            </section>
-        </main>
-=======
                         <div class="card-description min-h-[3rem]">
                             <p class="text-gray-600 line-clamp-3">{{ company.description }}</p>
                         </div>
@@ -229,7 +125,6 @@
             </div>
         </section>
     </div>
->>>>>>> 565b189 (feat: icon color and position)
 {% else %}
     <div class="container px-4 py-8 mx-auto">
         <h1 class="mb-6 text-3xl font-bold">Welcome to Our Site!</h1>

--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -16,6 +16,7 @@
                     </form>
                 </div>
             </div>
+<<<<<<< HEAD
         </header>
         <div class="container px-4 py-8 mx-auto">
             <section class="mb-12">
@@ -23,6 +24,81 @@
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                     {% for job in jobs %}
                         <div class="relative p-4 bg-white rounded-lg shadow hover:shadow-xl">
+=======
+        </div>
+    </header>
+    <div class="container px-4 py-8 mx-auto">
+        <section class="mb-12">
+          <div class="flex items-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-6 h-6 mr-2 text-red-500" fill="currentColor">
+                <path d="M159.3 5.4c7.8-7.3 19.9-7.2 27.7 .1c27.6 25.9 53.5 53.8 77.7 84c11-14.4 23.5-30.1 37-42.9c7.9-7.4 20.1-7.4 28 .1c34.6 33 63.9 76.6 84.5 118c20.3 40.8 33.8 82.5 33.8 111.9C448 404.2 348.2 512 224 512C98.4 512 0 404.1 0 276.5c0-38.4 17.8-85.3 45.4-131.7C73.3 97.7 112.7 48.6 159.3 5.4zM225.7 416c25.3 0 47.7-7 68.8-21c42.1-29.4 53.4-88.2 28.1-134.4c-4.5-9-16-9.6-22.5-2l-25.2 29.3c-6.6 7.6-18.5 7.4-24.7-.5c-16.5-21-46-58.5-62.8-79.8c-6.3-8-18.3-8.1-24.7-.1c-33.8 42.5-50.8 69.3-50.8 99.4C112 375.4 162.6 416 225.7 416z"/>
+            </svg>
+            <h2 class="text-2xl font-bold">熱門職缺</h2>
+        </div>
+        
+        
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {% for job in jobs %}
+                    <div class="relative p-4 bg-white rounded-lg shadow hover:shadow-xl">
+                        <div class="flex items-center mb-4">
+                            {% if job.company.logo %}
+                                <img src="{{ job.company.logo.url }}" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
+                            {% else %}
+                                <img src="/static/images/default_logo.jpg" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
+                            {% endif %}
+                            <div>
+                                <h3 class="text-lg font-semibold">{{ job.title }}</h3>
+                                <p class="font-semibold text-blue-600">{{ job.company.company_name }}</p>
+                            </div>
+                        </div>
+                        <div class="flex items-center space-x-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                            </svg>
+                            <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
+                            <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/>
+                            </svg>
+                            <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
+                        </div>
+                        <div class="absolute flex flex-col items-center justify-end space-y-2 bottom-4 right-4">
+                            <form class="inline" action="{% url 'users:collect' %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="job_id" value="{{ job.id }}">
+                                <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                        <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                    </svg>
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </section>
+        <section>
+          <div class="flex items-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-6 h-6 mr-2 text-blue-500" fill="currentColor">
+                <path d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.2s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"/>
+            </svg>
+            <h2 class="text-2xl font-bold">推薦公司</h2>
+        </div>
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                {% for company in companies %}
+                    <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
+                        <div class="relative p-2">
+                            {% if company.banner %}
+                                <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                    <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                                </div>
+                            {% else %}
+                                <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                    <img src="/static/images/default_banner.jpg" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="flex-grow p-4">
+>>>>>>> 96a41dd (feat: add icon)
                             <div class="flex items-center mb-4">
                                 {% if job.company.logo %}
                                     <img src="{{ job.company.logo.url }}" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">

--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -1,108 +1,121 @@
 {% extends 'frontend.html' %}
+{% load humanize %}
 {% block content %}
 {% if user.is_authenticated %}
-    <div class="min-h-screen flex flex-col">
-        <header class="bg-blue-50 py-8 text-center">
-          <div class="container mx-auto px-4">
-            <h1 class="text-2xl font-bold">拓展求職視野，尋找理想工作</h1>
-            <div class="mt-6 flex justify-center flex-wrap">
-              <input
-                type="text"
-                placeholder="找工作、公司..."
-                class="p-2 border border-gray-300 rounded-l-lg w-full md:w-2/3"
-              />
-              <button
-                class="p-2 bg-blue-500 text-white rounded-r-lg w-full md:w-auto"
-              >
-                搜尋
-              </button>
+    <div class="flex flex-col min-h-screen">
+        <header class="sticky z-10 w-full py-8 text-center bg-blue-50 top-16">
+            <div class="container px-4 mx-auto">
+                <h1 class="text-2xl font-bold">拓展求職視野，尋找理想工作</h1>
+                <div class="flex flex-wrap justify-center mt-6">
+                    <form action="{% url 'users:home' %}" method="get" class="flex w-full md:w-2/3">
+                        <input type="text" name="q" placeholder="找工作、公司..." class="flex-grow p-2 border border-gray-300 rounded-l-lg focus:outline-none focus:border-indigo-500" value="{{ request.GET.q|default:'' }}"/>
+                        <button type="submit" class="p-2 text-white bg-blue-500 rounded-r-lg">搜尋</button>
+                        {% if request.GET.q %}
+                            <a href="{% url 'users:home' %}" class="p-2 ml-2 text-white bg-red-500 rounded-lg">取消搜尋</a>
+                        {% endif %}
+                    </form>
+                </div>
             </div>
-          </div>
         </header>
-        <main class="flex-grow">
-          <section class="py-8">
-            <div class="container mx-auto px-4">
-              <h2 class="text-xl font-bold mb-4">熱門職缺</h2>
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                <div class="bg-white border border-gray-200 p-4 rounded-lg shadow">
-                  <h3 class="font-semibold mb-2">全支付-Android資深軟體工程師</h3>
-                  <p>公司名: 全支付</p>
-                  <p>地點: 台北市</p>
-                  <p>薪資: NT$ 40,000 - 50,000</p>
+        <div class="container px-4 py-8 mx-auto">
+            <section class="mb-12">
+                <h2 class="mb-4 text-2xl font-bold">熱門職缺</h2>
+                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    {% for job in jobs %}
+                        <div class="relative p-4 bg-white rounded-lg shadow hover:shadow-xl">
+                            <div class="flex items-center mb-4">
+                                {% if job.company.logo %}
+                                    <img src="{{ job.company.logo.url }}" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
+                                {% else %}
+                                    <img src="/static/images/default_logo.jpg" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
+                                {% endif %}
+                                <div>
+                                    <h3 class="text-lg font-semibold">{{ job.title }}</h3>
+                                    <p class="font-semibold text-blue-600">{{ job.company.company_name }}</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center space-x-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                    <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                                </svg>
+                                <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                    <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/>
+                                </svg>
+                                <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
+                            </div>
+                            <div class="absolute flex flex-col items-center justify-end space-y-2 bottom-4 right-4">
+                                <form class="inline" action="{% url 'users:collect' %}" method="post">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="job_id" value="{{ job.id }}">
+                                    <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                            <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                        </svg>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    {% endfor %}
                 </div>
-                <div class="bg-white border border-gray-200 p-4 rounded-lg shadow">
-                  <h3 class="font-semibold mb-2">Senior Software Engineer</h3>
-                  <p>公司名: AIFIAN</p>
-                  <p>地點: 台北市</p>
-                  <p>薪資: NT$ 1,200,000 - 2,000,000</p>
+            </section>
+            <section>
+                <h2 class="mb-4 text-2xl font-bold">推薦公司</h2>
+                <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                    {% for company in companies %}
+                        <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
+                            <div class="relative p-2">
+                                {% if company.banner %}
+                                    <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                        <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                                    </div>
+                                {% else %}
+                                    <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                        <img src="/static/images/default_banner.jpg" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                                    </div>
+                                {% endif %}
+                            </div>
+                            <div class="flex-grow p-4">
+                                <div class="flex items-center mb-4">
+                                    {% if company.logo %}
+                                        <img src="{{ company.logo.url }}" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
+                                    {% else %}
+                                        <img src="/static/images/default_logo.jpg" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
+                                    {% endif %}
+                                    <h2 class="text-xl font-semibold truncate">{{ company.company_name }}</h2>
+                                </div>
+                                <div class="card-description min-h-[3rem]">
+                                    <p class="text-gray-600 line-clamp-3">{{ company.description }}</p>
+                                </div>
+                            </div>
+                            <div class="flex-shrink-0 p-4">
+                                <div class="flex items-end justify-between">
+                                    <div class="flex items-center space-x-2">
+                                        <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                            <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                                        </svg>
+                                        <p class="flex items-center text-xs text-gray-600">{{ company.address|slice:":3" }}</p>
+                                        <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                            <path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/>
+                                        </svg>
+                                        <p class="flex items-center text-xs text-gray-600">{{ company.type }}</p>
+                                    </div>
+                                    <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                            <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
                 </div>
-                <div class="bg-white border border-gray-200 p-4 rounded-lg shadow">
-                  <h3 class="font-semibold mb-2">Web Full-Stack Engineer</h3>
-                  <p>公司名: dentall 台灣</p>
-                  <p>地點: 台北市</p>
-                  <p>薪資: NT$ 40,000 - 95,000</p>
-                </div>
-              </div>
-            </div>
-          </section>
-          <section class="bg-white py-8">
-            <div class="container mx-auto px-4">
-              <h2 class="text-xl font-bold mb-4">推薦公司</h2>
-              <div class="flex justify-between gap-4">
-                <div
-                  class="bg-white border border-gray-200 p-4 rounded-lg shadow w-full md:w-1/4"
-                >
-                  <h3 class="font-semibold mb-2">TeamJob</h3>
-                  <p>公司介紹...</p>
-                  <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugit
-                    quis nobis ducimus saepe magni id provident, assumenda voluptas
-                    accusamus sed temporibus minus, earum doloremque impedit?
-                    Perferendis veniam consequuntur beatae impedit.
-                  </p>
-                </div>
-                <div
-                  class="bg-white border border-gray-200 p-4 rounded-lg shadow w-full md:w-1/4"
-                >
-                  <h3 class="font-semibold mb-2">DollBank</h3>
-                  <p>公司介紹...</p>
-                  <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugit
-                    quis nobis ducimus saepe magni id provident, assumenda voluptas
-                    accusamus sed temporibus minus, earum doloremque impedit?
-                    Perferendis veniam consequuntur beatae impedit.
-                  </p>
-                </div>
-                <div
-                  class="bg-white border border-gray-200 p-4 rounded-lg shadow w-full md:w-1/4"
-                >
-                  <h3 class="font-semibold mb-2">URBAN</h3>
-                  <p>公司介紹...</p>
-                  <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugit
-                    quis nobis ducimus saepe magni id provident, assumenda voluptas
-                    accusamus sed temporibus minus, earum doloremque impedit?
-                    Perferendis veniam consequuntur beatae impedit.
-                  </p>
-                </div>
-                <div
-                  class="bg-white border border-gray-200 p-4 rounded-lg shadow w-full md:w-1/4"
-                >
-                  <h3 class="font-semibold mb-2">PH 百瑞國際</h3>
-                  <p>公司介紹...</p>
-                  <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugit
-                    quis nobis ducimus saepe magni id provident, assumenda voluptas
-                    accusamus sed temporibus minus, earum doloremque impedit?
-                    Perferendis veniam consequuntur beatae impedit.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </section>
+            </section>
         </main>
 {% else %}
-    <h1>Welcome to Our Site!</h1>
-    <p>Please <a href="{% url 'users:login' %}">login</a> or <a href="{% url 'users:register' %}">register</a>.</p>
+    <div class="container px-4 py-8 mx-auto">
+        <h1 class="mb-6 text-3xl font-bold">Welcome to Our Site!</h1>
+        <p class="mb-4">Please <a href="{% url 'users:login' %}" class="text-blue-500 underline">login</a> or <a href="{% url 'users:register' %}" class="text-blue-500 underline">register</a>.</p>
+    </div>
 {% endif %}
 {% endblock %}

--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -83,7 +83,7 @@
             </div>
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                 {% for company in companies %}
-                <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
+                <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl lg:col-span-1">
                     <div class="relative p-2">
                         {% if company.banner %}
                             <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
@@ -213,11 +213,15 @@
                                 </svg>
                                 <p class="flex items-center text-xs text-gray-600">{{ company.type }}</p>
                             </div>
-                            <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
-                                    <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
-                                </svg>
-                            </button>
+                            <form action="{% url 'users:collect' %}" method="post" class="flex-shrink-0">
+                                {% csrf_token %}
+                                <input type="hidden" name="company_id" value="{{ company.id }}">
+                                <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                        <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                    </svg>
+                                </button>
+                            </form>
                         </div>
                     </div>                    
                 </div>

--- a/templates/users/home.html
+++ b/templates/users/home.html
@@ -29,17 +29,15 @@
     </header>
     <div class="container px-4 py-8 mx-auto">
         <section class="mb-12">
-          <div class="flex items-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-6 h-6 mr-2 text-red-500" fill="currentColor">
-                <path d="M159.3 5.4c7.8-7.3 19.9-7.2 27.7 .1c27.6 25.9 53.5 53.8 77.7 84c11-14.4 23.5-30.1 37-42.9c7.9-7.4 20.1-7.4 28 .1c34.6 33 63.9 76.6 84.5 118c20.3 40.8 33.8 82.5 33.8 111.9C448 404.2 348.2 512 224 512C98.4 512 0 404.1 0 276.5c0-38.4 17.8-85.3 45.4-131.7C73.3 97.7 112.7 48.6 159.3 5.4zM225.7 416c25.3 0 47.7-7 68.8-21c42.1-29.4 53.4-88.2 28.1-134.4c-4.5-9-16-9.6-22.5-2l-25.2 29.3c-6.6 7.6-18.5 7.4-24.7-.5c-16.5-21-46-58.5-62.8-79.8c-6.3-8-18.3-8.1-24.7-.1c-33.8 42.5-50.8 69.3-50.8 99.4C112 375.4 162.6 416 225.7 416z"/>
-            </svg>
-            <h2 class="text-2xl font-bold">熱門職缺</h2>
-        </div>
-        
-        
+            <div class="flex items-center mb-4">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-6 h-6 mr-2 text-red-500" fill="currentColor">
+                    <path d="M159.3 5.4c7.8-7.3 19.9-7.2 27.7 .1c27.6 25.9 53.5 53.8 77.7 84c11-14.4 23.5-30.1 37-42.9c7.9-7.4 20.1-7.4 28 .1c34.6 33 63.9 76.6 84.5 118c20.3 40.8 33.8 82.5 33.8 111.9C448 404.2 348.2 512 224 512C98.4 512 0 404.1 0 276.5c0-38.4 17.8-85.3 45.4-131.7C73.3 97.7 112.7 48.6 159.3 5.4zM225.7 416c25.3 0 47.7-7 68.8-21c42.1-29.4 53.4-88.2 28.1-134.4c-4.5-9-16-9.6-22.5-2l-25.2 29.3c-6.6 7.6-18.5 7.4-24.7-.5c-16.5-21-46-58.5-62.8-79.8c-6.3-8-18.3-8.1-24.7-.1c-33.8 42.5-50.8 69.3-50.8 99.4C112 375.4 162.6 416 225.7 416z"/>
+                </svg>
+                <h2 class="text-2xl font-bold">熱門職缺</h2>
+            </div>
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                 {% for job in jobs %}
-                    <div class="relative p-4 bg-white rounded-lg shadow hover:shadow-xl">
+                    <div class="relative p-4 transition-shadow bg-white rounded-lg shadow hover:shadow-xl">
                         <div class="flex items-center mb-4">
                             {% if job.company.logo %}
                                 <img src="{{ job.company.logo.url }}" alt="{{ job.company.company_name }}" class="w-10 h-10 mr-4">
@@ -51,18 +49,18 @@
                                 <p class="font-semibold text-blue-600">{{ job.company.company_name }}</p>
                             </div>
                         </div>
-                        <div class="flex items-center space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
-                                <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
-                            </svg>
-                            <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
-                            <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
-                                <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/>
-                            </svg>
-                            <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
-                        </div>
-                        <div class="absolute flex flex-col items-center justify-end space-y-2 bottom-4 right-4">
-                            <form class="inline" action="{% url 'users:collect' %}" method="post">
+                        <div class="flex items-center justify-between space-x-2">
+                            <div class="flex items-center space-x-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                    <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                                </svg>
+                                <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                    <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2"/>
+                                </svg>
+                                <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
+                            </div>
+                            <form action="{% url 'users:collect' %}" method="post" class="flex-shrink-0">
                                 {% csrf_token %}
                                 <input type="hidden" name="job_id" value="{{ job.id }}">
                                 <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
@@ -74,29 +72,39 @@
                         </div>
                     </div>
                 {% endfor %}
-            </div>
+            </div>            
         </section>
         <section>
-          <div class="flex items-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-6 h-6 mr-2 text-blue-500" fill="currentColor">
-                <path d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.2s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"/>
-            </svg>
-            <h2 class="text-2xl font-bold">推薦公司</h2>
-        </div>
+            <div class="flex items-center mb-4">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="w-6 h-6 mr-2 text-red-500" fill="currentColor">
+                    <path d="M159.3 5.4c7.8-7.3 19.9-7.2 27.7 .1c27.6 25.9 53.5 53.8 77.7 84c11-14.4 23.5-30.1 37-42.9c7.9-7.4 20.1-7.4 28 .1c34.6 33 63.9 76.6 84.5 118c20.3 40.8 33.8 82.5 33.8 111.9C448 404.2 348.2 512 224 512C98.4 512 0 404.1 0 276.5c0-38.4 17.8-85.3 45.4-131.7C73.3 97.7 112.7 48.6 159.3 5.4zM225.7 416c25.3 0 47.7-7 68.8-21c42.1-29.4 53.4-88.2 28.1-134.4c-4.5-9-16-9.6-22.5-2l-25.2 29.3c-6.6 7.6-18.5 7.4-24.7-.5c-16.5-21-46-58.5-62.8-79.8c-6.3-8-18.3-8.1-24.7-.1c-33.8 42.5-50.8 69.3-50.8 99.4C112 375.4 162.6 416 225.7 416z"/>
+                </svg>
+                <h2 class="text-2xl font-bold">推薦公司</h2>
+            </div>
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                 {% for company in companies %}
-                    <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
-                        <div class="relative p-2">
-                            {% if company.banner %}
-                                <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
-                                    <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
-                                </div>
+                <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow bg-white rounded-lg shadow-md hover:shadow-xl">
+                    <div class="relative p-2">
+                        {% if company.banner %}
+                            <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                            </div>
+                        {% else %}
+                            <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                                <img src="/static/images/default_banner.jpg" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
+                            </div>
+                        {% endif %}
+                    </div>
+                    <div class="flex-grow p-4">
+                        <div class="flex items-center mb-4">
+                            {% if company.logo %}
+                                <img src="{{ company.logo.url }}" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
                             {% else %}
-                                <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
-                                    <img src="/static/images/default_banner.jpg" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
-                                </div>
+                                <img src="/static/images/default_logo.jpg" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
                             {% endif %}
+                            <h2 class="text-xl font-semibold truncate">{{ company.company_name }}</h2>
                         </div>
+<<<<<<< HEAD
                         <div class="flex-grow p-4">
 >>>>>>> 96a41dd (feat: add icon)
                             <div class="flex items-center mb-4">
@@ -188,6 +196,36 @@
                 </div>
             </section>
         </main>
+=======
+                        <div class="card-description min-h-[3rem]">
+                            <p class="text-gray-600 line-clamp-3">{{ company.description }}</p>
+                        </div>
+                    </div>
+                    <div class="flex-shrink-0 p-4">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center space-x-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                    <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                                </svg>
+                                <p class="flex items-center text-xs text-gray-600">{{ company.address|slice:":3" }}</p>
+                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                    <path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/>
+                                </svg>
+                                <p class="flex items-center text-xs text-gray-600">{{ company.type }}</p>
+                            </div>
+                            <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                    <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>                    
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+    </div>
+>>>>>>> 565b189 (feat: icon color and position)
 {% else %}
     <div class="container px-4 py-8 mx-auto">
         <h1 class="mb-6 text-3xl font-bold">Welcome to Our Site!</h1>

--- a/users/views.py
+++ b/users/views.py
@@ -65,8 +65,14 @@ class UserHomeView(PermissionRequiredMixin,TemplateView):
         user_jobs = User_Job.objects.filter(user=self.request.user).values_list('job_id', flat=True)
         if search_keyword:
             companies = Company.objects.filter(company_name__icontains=search_keyword)
+            jobs = Job.objects.filter(title__icontains=search_keyword).select_related('company')
+            company_ids_from_jobs = jobs.values_list('company_id', flat=True)
+            companies_from_jobs = Company.objects.filter(id__in=company_ids_from_jobs)
+            companies = companies | companies_from_jobs
+            companies = companies.distinct()
         else:
             companies = Company.objects.all()
+            jobs = Job.objects.select_related('company').all()
         context['companies'] = companies
         context['jobs'] = jobs
         context['resumes'] = resumes


### PR DESCRIPTION
- 依照軒佑做的users/home.html版面，將連結元素放回，並加設搜尋公司的功能（原本是只能搜尋職缺）
- 搜尋欄固定在上方，並設有取消搜尋的按鈕，以便回復全部資料的樣貌
- 搜尋關鍵字若為職缺，會帶出開設該職缺的公司卡片
- 若搜尋關鍵字只有公司名稱符合，只會出現公司卡片
- 有RWD設計
- 卡片增加懸浮陰影效果
- 職缺卡片排版參考[Yourator](https://www.yourator.co/)，圖片以公司logo呈現
- icon圖示暫時用SVG帶入方式，之後要改設為套件帶入 i 標籤方式，減少程式碼量（已開票 #200）
- 因為現在有設立navbar可連結使用者功能，所以移除原本上頁的連結項目（資料、履歷、登出）
- 熱門職缺跟推薦公司這部分，以後可以設定成課金的公司能呈現訊息在使用者登入畫面，以增加曝光度的功能
- 職缺收藏功能之前已經有做，點選愛心會有收藏效果，公司收藏功能還沒人做（之前已有開票 #166）


網頁：
<img width="1158" alt="截圖 2024-05-30 下午1 06 06" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/694ad49a-1db1-4ae6-80c5-8adc5835c046">

<img width="1150" alt="截圖 2024-05-30 下午1 06 41" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/de2d100a-b5d0-47ef-a6e8-9c0f926dabd2">


手機：
<img width="504" alt="截圖 2024-05-30 下午1 07 35" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/89c640f3-e8d4-4aed-bae7-7060c439b331">


<img width="496" alt="截圖 2024-05-30 中午12 48 56" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/feeb742a-0d40-4d71-b2f1-d450ee4741d5">



測試錄影（網頁）（檔案超過10MB，用外連方式）：
https://youtu.be/boZ0S-_6FNU

測試錄影（手機）（檔案超過10MB，用外連方式）：
https://youtu.be/NTx8YCx6I1g
