### PR TITLE
熱修：第三方登入跳轉路徑

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -233,7 +233,7 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 SITE_ID = int(os.getenv("SITE_ID", 1))
-LOGIN_REDIRECT_URL = "/users/"
+LOGIN_REDIRECT_URL = "/dashboard/"
 SOCIALACCOUNT_LOGIN_ON_GET = True
 
 


### PR DESCRIPTION
因為使用者登入路徑後來有改（原本/user/)，所以跳轉路徑又噴錯（但有成功登入），修改後就能正常了

原本噴：
<img width="1067" alt="截圖 2024-05-30 晚上11 29 33" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/77008f52-ee1c-494d-a4a6-30f2b4e3ecc2">

新登入路徑：
<img width="361" alt="截圖 2024-05-30 晚上11 39 25" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/832e2acd-cdcf-42c2-9b2b-8a887e583843">


已修復：


https://github.com/astrocamp/16th-EngiLink/assets/149367532/f9debff3-0589-4174-9467-913ebac9e8c1


