### PR TITLE
找工作卡片圖片太長

### DIFF
--- a/templates/jobs/list.html
+++ b/templates/jobs/list.html
@@ -1,35 +1,39 @@
 {% extends "backend.html" %}
 {% load humanize %}
 {% block content %}
-<div class="bg-gray-100">
+<div>
     <div class="container px-4 py-8 mx-auto">
-        <div class="space-y-6">
+        <div class="mx-auto space-y-6 md:w-4/5 lg:w-2/3">
             {% for job in jobs %}
-                <div class="flex flex-col items-start justify-between p-4 bg-white rounded-lg shadow-lg md:flex-row md:items-center">
-                    <div class="w-full mb-4 md:w-1/3 md:mb-0 md:mr-4">
-                        <img src="{{ job.company_banner_url }}" alt="公司圖片" class="object-cover w-full h-24 rounded">
+                <div class="flex flex-col transition-shadow duration-300 bg-white rounded-lg shadow-lg hover:shadow-2xl md:flex-row">
+                    <div class="w-full h-36 md:w-1/3">
+                        <img src="{{ job.company_banner_url }}" alt="公司圖片" class="object-cover w-full h-full rounded-t-lg md:rounded-t-none md:rounded-l-lg">
                     </div>
-                    <div class="flex flex-col items-start justify-between w-full space-y-4 md:w-2/3 md:flex-row md:items-center md:space-y-0">
-                        <div class="flex flex-col flex-grow space-y-4 md:mr-4">
-                            <h2 class="text-2xl font-bold">{{ job.title }}</h2>
-                            <div class="flex items-center space-x-2">
+                    <div class="flex flex-col justify-between p-4 space-y-4 md:flex-row md:space-y-0 md:items-center md:w-2/3">
+                        <div class="flex-grow overflow-hidden md:flex md:flex-col md:justify-center md:max-w-full">
+                            <h2 class="text-2xl font-bold truncate">{{ job.title }}</h2>
+                            <div class="flex items-center mt-2 space-x-2">
                                 <img src="{{ job.company_logo_url }}" alt="公司Logo" class="object-cover w-6 h-6 rounded">
-                                <p class="text-lg">{{ job.company_name }}</p>
+                                <p class="max-w-full text-lg truncate">{{ job.company_name }}</p>
                             </div>
-                            <div class="flex items-center space-x-2">
-                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 384 512" fill="currentColor"><path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/></svg>
+                            <div class="flex items-center mt-2 space-x-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-500" viewBox="0 0 384 512" fill="currentColor">
+                                    <path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/>
+                                </svg>
                                 <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
-                                <svg xmlns="http://www.w3.org/2000/svg" style="width: 1em; height: 1em;" class="text-gray-500" viewBox="0 0 512 512" fill="currentColor"><path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/></svg>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-500" viewBox="0 0 512 512" fill="currentColor">
+                                    <path d="M320 96H192L144.6 24.9C137.5 14.2 145.1 0 157.9 0H354.1c12.8 0 20.4 14.2 13.3 24.9L320 96zM192 128H320c3.8 2.5 8.1 5.3 13 8.4C389.7 172.7 512 250.9 512 416c0 53-43 96-96 96H96c-53 0-96-43-96-96C0 250.9 122.3 172.7 179 136.4l0 0 0 0c4.8-3.1 9.2-5.9 13-8.4zm84 88c0-11-9-20-20-20s-20 9-20 20v14c-7.6 1.7-15.2 4.4-22.2 8.5c-13.9 8.3-25.9 22.8-25.8 43.9c.1 20.3 12 33.1 24.7 40.7c11 6.6 24.7 10.8 35.6 14l1.7 .5c12.6 3.8 21.8 6.8 28 10.7c5.1 3.2 5.8 5.4 5.9 8.2c.1 5-1.8 8-5.9 10.5c-5 3.1-12.9 5-21.4 4.7c-11.1-.4-21.5-3.9-35.1-8.5c-2.3-.8-4.7-1.6-7.2-2.4c-10.5-3.5-21.8 2.2-25.3 12.6s2.2 21.8 12.6 25.3c1.9 .6 4 1.3 6.1 2.1l0 0 0 0c8.3 2.9 17.9 6.2 28.2 8.4V424c0 11 9 20 20 20s20-9 20-20V410.2c8-1.7 16-4.5 23.2-9c14.3-8.9 25.1-24.1 24.8-45c-.3-20.3-11.7-33.4-24.6-41.6c-11.5-7.2-25.9-11.6-37.1-15l0 0-.7-.2c-12.8-3.9-21.9-6.7-28.3-10.5c-5.2-3.1-5.3-4.9-5.3-6.7c0-3.7 1.4-6.5 6.2-9.3c5.4-3.2 13.6-5.1 21.5-5c9.6 .1 20.2 2.2 31.2 5.2c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-6.5-1.7-13.7-3.4-21.1-4.7V216z"/>
+                                </svg>
                                 <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
                             </div>
                         </div>
-                        <div class="flex flex-row items-center justify-end w-full mt-4 space-x-4 md:flex-col md:items-start md:w-auto md:space-x-0 md:space-y-4 md:mt-0 md:flex-shrink-0">
+                        <div class="flex justify-end flex-shrink-0 space-x-4 md:justify-center md:flex-col md:items-end md:space-y-4 md:space-x-0">
                             {% if request.user.user_type == 1 %}
                             <div class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700"><a href="{% url 'users:apply' job.id %}">立即應徵</a></div>
-                            <a href="{% url 'users:collect' %}"><div class="px-4 py-2 text-gray-700 bg-gray-200 rounded hover:bg-gray-300">收藏職缺</div></a>
+                            <a href="{% url 'users:collect' %}"><div class="px-4 py-2 text-gray-700 bg-gray-200 rounded hover:bg-pink-200">收藏職缺</div></a>
                             {% else %}
                             <a href="{% url 'users:login' %}"><div class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700">立即應徵</div></a>
-                            <a href="{% url 'users:login' %}"><div class="px-4 py-2 text-gray-700 bg-gray-200 rounded hover:bg-gray-300">收藏職缺</div></a>
+                            <a href="{% url 'users:login' %}"><div class="px-4 py-2 text-gray-700 bg-gray-200 rounded hover:bg-pink-200">收藏職缺</div></a>
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
已修正，將大螢幕的卡片內縮，避免過長，圖片邊距取消
並添加懸停陰影效果、碰觸時收藏按鈕變粉紅色、過長文字截斷效果，保持卡片大小一致

網頁：
<img width="1297" alt="截圖 2024-05-31 凌晨1 03 14" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/96dd7ff9-9870-4d51-ad08-6fe72eae9f06">

手機：
<img width="501" alt="截圖 2024-05-31 凌晨1 03 27" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/48efe6ab-8455-483b-8e64-74d8c0b4da9c">


測試錄影：
https://youtu.be/3q-Gj8TrcK4