### PR TITLE
修改找公司圖片高於navbar選單問題

### DIFF
--- a/templates/companies/list.html
+++ b/templates/companies/list.html
@@ -7,16 +7,16 @@
     <div class="flex justify-end mb-4">
         <form action="{% url 'companies:company_list' %}" method="get" class="flex">
             <input type="text" name="q" placeholder="搜尋公司名稱" class="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:border-indigo-500">
-            <button type="submit" class="px-4 py-2 bg-indigo-500 text-white rounded-lg ml-2">Search</button>
+            <button type="submit" class="px-4 py-2 ml-2 text-white bg-indigo-500 rounded-lg">Search</button>
         </form>
     </div>
     <div class="container px-4 py-8 mx-auto">
-        <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {% for company in companies_list %}
-                <div class="flex flex-col justify-between h-full overflow-hidden bg-white rounded-lg shadow-md">
+                <div class="flex flex-col justify-between h-full overflow-hidden transition-shadow duration-300 bg-white rounded-lg shadow-md hover:shadow-xl">
                     <div class="relative p-2">
                         {% if company.banner %}
-                            <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5">
+                            <div class="relative w-full h-48 mb-0 flex justify-center items-center p-2.5 z-0">
                                 <img src="{{ company.banner.url }}" alt="{{ company.company_name }}" class="object-cover w-full h-48 rounded-lg m-2.5 mb-0">
                             </div>
                         {% else %}
@@ -25,7 +25,7 @@
                             </div>
                         {% endif %}
                     </div>
-                    <div class="flex-grow p-4">
+                    <div class="z-10 flex-grow p-4">
                         <div class="flex items-center mb-4">
                             {% if company.logo %}
                                 <img src="{{ company.logo.url }}" alt="{{ company.company_name }}" class="w-5 h-5 mr-2">
@@ -38,7 +38,7 @@
                             <p class="text-gray-600 line-clamp-3">{{ company.description }}</p>
                         </div>
                     </div>
-                    <div class="flex-shrink-0 p-4">
+                    <div class="z-10 flex-shrink-0 p-4">
                         <div class="flex items-end justify-between">
                             <div>
                                 <p class="flex items-center text-xs text-gray-600">
@@ -48,8 +48,10 @@
                                     <span class="mr-1 align-middle material-icons-outlined">work</span> {{ company.type }}
                                 </p>
                             </div>
-                            <button class="flex items-center justify-center w-8 h-8 text-white bg-blue-500 rounded-full hover:bg-pink-700">
-                                <span class="material-icons-outlined">favorite</span>
+                            <button type="submit" class="flex items-center justify-center w-8 h-8 text-white bg-gray-300 rounded-full hover:bg-pink-300">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="w-4 h-4 text-white fill-current">
+                                    <path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/>
+                                </svg>
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
- 修改掉原本找公司的圖片在手機模式下會高過navbar選單問題
- 並且將原本收藏愛心圖案是google front改用SVG，顏色也修改成配合其他頁面的效果（灰色->粉紅）
- 卡片增加懸停陰影效果

<img width="1318" alt="截圖 2024-05-31 下午6 07 59" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/2e8f84c8-db4f-40a5-9994-b394cc198844">


<img width="507" alt="截圖 2024-05-31 下午6 07 32" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/cb19e426-6da9-4889-8bb9-7ad5b7d34209">


測試錄影：
https://youtu.be/la9dh53-U9c

