### PR TITLE
jobs/list/ 畫面上的 立即應徵 按鈕，a 連結沒有包好

### DIFF
--- a/templates/jobs/list.html
+++ b/templates/jobs/list.html
@@ -17,15 +17,17 @@
                                 <p class="max-w-full text-lg truncate">{{ job.company_name }}</p>
                             </div>
                             <div class="flex items-center mt-2 space-x-2">
-                                <i class="fa-solid fa-location-dot w-4 h-4 text-gray-500"></i> 
+                                <i class="w-4 h-4 text-gray-500 fa-solid fa-location-dot"></i> 
                                 <p class="text-gray-700">{{ job.address|slice:":3" }}</p>
-                                <i class="fa-solid fa-sack-dollar w-4 h-4 text-gray-500"></i>
+                                <i class="w-4 h-4 text-gray-500 fa-solid fa-sack-dollar"></i>
                                 <p class="text-gray-700">NT${{ job.salary|intcomma }}</p>
                             </div>
                         </div>
                         <div class="flex justify-end flex-shrink-0 space-x-4 md:justify-center md:flex-col md:items-end md:space-y-4 md:space-x-0">
                             {% if request.user.user_type == 1 %}
-                            <div class="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700"><a href="{% url 'users:apply' job.id %}">立即應徵</a></div>
+                            <a href="{% url 'users:apply' job.id %}" class="block px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700">
+                                立即應徵
+                            </a>                            
                             <form action="{% url 'users:collect' %}" method="post" class="inline" hx-post="{% url 'users:collect' %}" hx-target="#collect-button-{{ job.id }}" hx-swap="outerHTML">
                                 {% csrf_token %}
                                 <input type="hidden" name="job_id" value="{{ job.id }}">


### PR DESCRIPTION
原本a連結只有在“立即應徵”的字上，已修改a連結範圍為整個按鈕

<img width="660" alt="截圖 2024-06-07 中午12 29 23" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/9a128b3f-a908-4f45-bacb-710dd8b36175">
