### PR TITLE
修正LINE Pay付款跳轉錯誤路徑

### DIFF
--- a/about/views.py
+++ b/about/views.py
@@ -45,7 +45,7 @@ def create_line_pay_request(amount, currency, order_id):
             }
         ],
         'redirectUrls': {
-            'confirmUrl': settings.ONLINE_URL + "/linepay/confirm/",
+            'confirmUrl': settings.ONLINE_URL + "/about/",
             'cancelUrl': settings.ONLINE_URL + "/linepay/cancel/"
         }
     }
@@ -129,7 +129,7 @@ class LinePayRequestView(View):
                 }
             ],
             "redirectUrls": {
-                "confirmUrl": f"{settings.ONLINE_URL}/callback/",
+                "confirmUrl": f"{settings.ONLINE_URL}/about/",
                 "cancelUrl": f"{settings.ONLINE_URL}/linepay/cancel/"
             }
         }, separators=(',', ':'))


### PR DESCRIPTION
原本是/linepay/confirm，修改成about
ngrok測試沒問題，會跳回about，但部署上線後反而是跳到這個來

以下是修改的：
<img width="572" alt="截圖 2024-06-13 凌晨12 22 40" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/5ee26136-2f4e-4254-a6b9-d333d8b7b2aa">


<img width="605" alt="截圖 2024-06-13 凌晨12 23 05" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/0b1b8cc7-2d09-41b4-9953-b4d4fc50445a">




噴錯的頁面：（跳到沒有製作跟設定路徑的/linepay/confirm，所以可能是這個影響）
<img width="1055" alt="截圖 2024-06-12 晚上10 16 58" src="https://github.com/astrocamp/16th-EngiLink/assets/149367532/db3cb4dc-7827-4ef7-8152-72b5a5b5a26a">
